### PR TITLE
Updated Workflow - Only Allow Development/Hotfix Merges to Main

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,21 +20,41 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: Check branch names
+      id: check_branch_names
+      run: |
+        BASE_REF="${{ github.base_ref }}"
+        HEAD_REF="${{ github.head_ref }}"
+
+        echo "Base ref: $BASE_REF"
+        echo "Head ref: $HEAD_REF"
+
+        if [[ "$BASE_REF" == "main" && ! (“$HEAD_REF == “development || "$HEAD_REF" =~ ^hotfix_) ]]; then
+          echo "Main cannot be merged from branches other than development or hotfixes. Exiting..."
+          exit 1
+        fi
+          
+        echo "Branches are merge compatible."
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        
     - name: Test with pytest
       run: |
         pytest


### PR DESCRIPTION
Added a step to the workflow to only allow branches with the name development or with a name starting with hotfix_ to pass. This will need to be tested, and can only be tested by merging it all the way to main.